### PR TITLE
Hidden input is breaks table

### DIFF
--- a/src/MultipleInput.php
+++ b/src/MultipleInput.php
@@ -199,24 +199,18 @@ class MultipleInput extends InputWidget
     {
         if (empty($this->template)) {
             $cells = [];
-            $hiddenInputs = [];
             foreach ($this->columns as $columnIndex => $column) {
                 /* @var $column MultipleInputColumn */
                 $value = 'multiple-' . $column->name . '-value';
                 $this->replacementKeys[$value] = $column->defaultValue;
                 $value = '{' . $value . '}';
 
-                if ($column->isHiddenInput()) {
-                    $hiddenInputs[] = $column->renderCellContent($value);
-                } else {
-                    $cells[] = $column->renderCellContent($value);
-                }
+                $cells[] = $column->renderCellContent($value);
             }
             if (is_null($this->limit) || $this->limit > 1) {
                 $cells[] = $this->renderActionColumn();
             }
 
-            $this->template = implode("\n", $hiddenInputs);
             $this->template .= Html::tag('tr', implode("\n", $cells), [
                 'class' => 'multiple-input-list__item',
             ]);

--- a/src/MultipleInputColumn.php
+++ b/src/MultipleInputColumn.php
@@ -114,12 +114,11 @@ class MultipleInputColumn extends Object
      */
     public function renderHeaderCell()
     {
-        if ($this->isHiddenInput()) {
-            return null;
-        }
-
         $options = $this->headerOptions;
         Html::addCssClass($options, 'list-cell__' . $this->name);
+        if ($this->isHiddenInput()) {
+            Html::addCssClass($options, 'list-cell__hidden');
+        }
         return Html::tag('th', $this->title, $options);
     }
 
@@ -193,15 +192,13 @@ class MultipleInputColumn extends Object
                 }
         }
 
-        if ($this->isHiddenInput()) {
-            return $input;
-        }
-
         $input = Html::tag('div', $input, [
             'class' => 'form-group field-' . $options['id'],
         ]);
-        return Html::tag('td', $input, [
-            'class' => 'list-cell__' . $this->name,
-        ]);
+        $cellOptions = ['class' => 'list-cell__' . $this->name];
+        if ($this->isHiddenInput()) {
+            Html::addCssClass($cellOptions, 'list-cell__hidden');
+        }
+        return Html::tag('td', $input, $cellOptions);
     }
 }

--- a/src/assets/src/css/multiple-input.css
+++ b/src/assets/src/css/multiple-input.css
@@ -30,3 +30,6 @@ table.multiple-input-list tr > th {
 .multiple-input-list__item .list-cell__button {
     width: 40px;
 }
+.multiple-input-list .list-cell__hidden {
+    display: none;
+}


### PR DESCRIPTION
Hi!

I'm using next a code with hidden input for editing my models:

```php
<?= $form->field($model, 'items')->label(false)->widget(MultipleInput::className(), [
    'columns' => [
        [
            'name' => 'id',
            'type' => MultipleInputColumn::TYPE_HIDDEN_INPUT,
        ],
        [
            'name' => 'title',
            'title' => $model->getAttributeLabel('title'),
            'type' => MultipleInputColumn::TYPE_TEXT_INPUT,
        ],
        [
            'name' => 'description',
            'title' => $model->getAttributeLabel('description'),
            'type' => \vova07\imperavi\Widget::className(),
            'options' => [
                'settings' => [
                    'lang' => Yii::$app->language,
                    'toolbarFixed' => false,
                    'imageUpload' => Url::to(['site/upload']),
                    'fileUpload' => Url::to(['site/upload']),
                    'buttons' => ['html', 'bold', 'italic', 'deleted', 'unorderedlist', 'orderedlist', 'link', 'alignment'],
                ],
            ],
        ],
    ],
]) ?>
```

Hidden input is breaks a table. Look here:

![Alt text](https://monosnap.com/file/94ifMnWWEbkzTu7Dw0XgY688bUfVV9.png)

I did some changes in your code and now it doesn't breaks a table and allows to work comfortably. My idea is that we display all table columns (with hidden inputs too) and hide these columns using CSS.

