### PR TITLE
Update renderCheckbox

### DIFF
--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -302,7 +302,7 @@ abstract class BaseColumn extends Object
         if (!isset($options['label'])) {
             $options['label'] = '';
         }
-        $input = Html::checkbox($name, $value, $options);
+        $input = Html::hiddenInput($name, 0, $options) . Html::checkbox($name, $value, $options);
         return Html::tag('div', $input, ['class' => 'checkbox']);
     }
 


### PR DESCRIPTION
I have a small issue with working of the checkbox column. When turned off checkbox value isn't sent to server side. This is particularity of HTML (if we have turned on checkbox then value is sent otherwise no). The fix is to add hidden input with turned off value (default value). Look the same solution in Yii2 https://github.com/yiisoft/yii2/blob/master/framework/helpers/BaseHtml.php#L715

I did solution for a boolean field and it's not universal solving of the problem. What do you think about it? Maybe you have best solution?