### PR TITLE
add check for closure in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,12 @@ or anonymous function which return array of items and has the following signatur
 function($data) {}
 ```
 
-**options** *array*: the HTML attributes for the input
+**options** *array*|*Closure*: the HTML attributes for the input, you can set it as array
+or an anonymous function with the following signature: 
+
+```php
+function($data) {}
+```
 
 **headerOptions** *array*: the HTML attributes for the header cell
 

--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -229,10 +229,12 @@ abstract class BaseColumn extends Object
     public function renderInput($name, $options)
     {
         if ($this->options instanceof \Closure) {
-            $this->options = call_user_func($this->options, $this->getModel());
+            $optionsExt = call_user_func($this->options, $this->getModel());
+        } else {
+            $optionsExt = $this->options;
         }
         
-        $options = Arrayhelper::merge($this->options, $options);
+        $options = Arrayhelper::merge($optionsExt, $options);
         $method = 'render' . Inflector::camelize($this->type);
         $value = $this->prepareValue();
 

--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -228,6 +228,10 @@ abstract class BaseColumn extends Object
      */
     public function renderInput($name, $options)
     {
+        if ($this->options instanceof \Closure) {
+            $this->options = call_user_func($this->options, $this->getModel());
+        }
+        
         $options = Arrayhelper::merge($this->options, $options);
         $method = 'render' . Inflector::camelize($this->type);
         $value = $this->prepareValue();


### PR DESCRIPTION
check for Closure need for example disabled same elements, when model contains same option:
```
[
    'name' => 'zip',
    'title' => 'Индекс',
    'type' => BaseColumn::TYPE_TEXT_INPUT,
    'options' => function ($item) {
        return $item && $item->city ? ['readonly' => 'readonly'] : [];
    }
]
```