### PR TITLE
fix double "add button" for empty list

### DIFF
--- a/src/renderers/TableRenderer.php
+++ b/src/renderers/TableRenderer.php
@@ -59,7 +59,12 @@ class TableRenderer extends BaseRenderer
         }
 
         if ($this->limit === null || ($this->limit >= 1 && $this->limit !== $this->min)) {
-            $button = $this->min === 0 || $this->isAddButtonPositionHeader() ? $this->renderAddButton() : '';
+            $button = '';
+            if (($this->min === 0 && $this->isAddButtonPositionRow())
+                || $this->isAddButtonPositionHeader()
+            ) {
+                $button = $this->renderAddButton();
+            }
 
             $cells[] = Html::tag('th', $button, [
                 'class' => 'list-cell__button'


### PR DESCRIPTION
This PR fixes rendering for such config:
```php
[
    'min' => 0,
    'addButtonPosition' => MultipleInput::POS_FOOTER,
]
```
With this config will be 2 add buttons generated: in header and in footer.