### PR TITLE
Added before row position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Yii2 multiple input change log
 
 2.11.0
 ======
+- Added the possibility to substitute buttons before rows
 
 2.10.0
 ======

--- a/src/MultipleInput.php
+++ b/src/MultipleInput.php
@@ -29,6 +29,7 @@ class MultipleInput extends InputWidget
 {
     const POS_HEADER    = RendererInterface::POS_HEADER;
     const POS_ROW       = RendererInterface::POS_ROW;
+    const POS_ROW_BEGIN = RendererInterface::POS_ROW_BEGIN;
     const POS_FOOTER    = RendererInterface::POS_FOOTER;
 
     /**

--- a/src/renderers/BaseRenderer.php
+++ b/src/renderers/BaseRenderer.php
@@ -375,6 +375,14 @@ abstract class BaseRenderer extends Object implements RendererInterface
         return in_array(self::POS_ROW, $this->addButtonPosition);
     }
 
+    /**
+     * @return bool
+     */
+    protected function isAddButtonPositionRowBegin()
+    {
+        return in_array(self::POS_ROW_BEGIN, $this->addButtonPosition);
+    }
+
     private function prepareIndexPlaceholder()
     {
         $this->indexPlaceholder = 'multiple_index_' . $this->id;

--- a/src/renderers/RendererInterface.php
+++ b/src/renderers/RendererInterface.php
@@ -17,6 +17,7 @@ interface RendererInterface
 {
     const POS_HEADER    = 'header';
     const POS_ROW       = 'row';
+    const POS_ROW_BEGIN = 'row_begin';
     const POS_FOOTER    = 'footer';
 
     /**

--- a/src/renderers/TableRenderer.php
+++ b/src/renderers/TableRenderer.php
@@ -172,6 +172,10 @@ class TableRenderer extends BaseRenderer
     {
         $cells = [];
         $hiddenInputs = [];
+        $isLastRow = $this->max === $this->min;
+        if (!$isLastRow && $this->isAddButtonPositionRowBegin()) {
+            $cells[] = $this->renderActionColumn($index);
+        }
 
         foreach ($this->columns as $column) {
             /* @var $column BaseColumn */
@@ -183,7 +187,7 @@ class TableRenderer extends BaseRenderer
             }
         }
 
-        if ($this->max !== $this->min) {
+        if (!$isLastRow && $this->isAddButtonPositionRow()) {
             $cells[] = $this->renderActionColumn($index);
         }
 
@@ -292,7 +296,7 @@ class TableRenderer extends BaseRenderer
         if ($index < $this->min) {
             return '';
         } elseif ($index === $this->min) {
-            return $this->isAddButtonPositionRow() ? $this->renderAddButton() : '';
+            return ($this->isAddButtonPositionRow() || $this->isAddButtonPositionRowBegin()) ? $this->renderAddButton() : '';
         } else {
             return $this->renderRemoveButton();
         }


### PR DESCRIPTION
Иногда это нужно для того, чтобы пользователи сразу замечали возможность добавить. Тестирование на рядовом пользователе показало, что если этот плюс будет после строки как раньше, то высока вероятность того, что он его не заметит=) Поэтому я добавил возможность отрисовывать кнопки добавления\удаления в начале строки таблицы