### PR TITLE
Rename yii\base\Object to yii\base\BaseObject.

### DIFF
--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -11,7 +11,7 @@ namespace unclead\multipleinput\components;
 use Closure;
 use yii\base\InvalidConfigException;
 use yii\base\Model;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\db\ActiveRecordInterface;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Html;


### PR DESCRIPTION
For compatibiliy with [PHP 7.2 which does not allow classes to be named Object anymore], we needed to rename yii\base\Object to yii\base\BaseObject.