### PR TITLE
Rename yii\base\Object to yii\base\BaseObject.

### DIFF
--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -11,7 +11,7 @@ namespace unclead\multipleinput\components;
 use Closure;
 use yii\base\InvalidConfigException;
 use yii\base\Model;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\db\ActiveRecordInterface;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
@@ -23,7 +23,7 @@ use unclead\multipleinput\renderers\BaseRenderer;
  *
  * @package unclead\multipleinput\components
  */
-abstract class BaseColumn extends Object
+abstract class BaseColumn extends BaseObject
 {
     const TYPE_TEXT_INPUT       = 'textInput';
     const TYPE_HIDDEN_INPUT     = 'hiddenInput';

--- a/src/renderers/BaseRenderer.php
+++ b/src/renderers/BaseRenderer.php
@@ -15,7 +15,7 @@ use yii\helpers\Json;
 use yii\base\InvalidConfigException;
 use yii\base\Model;
 use yii\base\NotSupportedException;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\db\ActiveRecordInterface;
 use yii\web\View;
 use yii\widgets\ActiveForm;
@@ -29,7 +29,7 @@ use unclead\multipleinput\components\BaseColumn;
  * Class BaseRenderer
  * @package unclead\multipleinput\renderers
  */
-abstract class BaseRenderer extends Object implements RendererInterface
+abstract class BaseRenderer extends BaseObject implements RendererInterface
 {
     /**
      * @var string the ID of the widget


### PR DESCRIPTION
For compatibiliy with [PHP 7.2 which does not allow classes to be named Object anymore], we needed to rename yii\base\Object to yii\base\BaseObject.