### PR TITLE
Added compatibility of relations as attribute

### DIFF
--- a/src/MultipleInput.php
+++ b/src/MultipleInput.php
@@ -168,6 +168,7 @@ class MultipleInput extends InputWidget
         }
 
         if ($this->model instanceof Model) {
+            $this->model->refresh();
             $data = ($this->model->hasProperty($this->attribute) || isset($this->model->{$this->attribute}))
                 ? ArrayHelper::getValue($this->model, $this->attribute, [])
                 : [];

--- a/src/MultipleInput.php
+++ b/src/MultipleInput.php
@@ -168,7 +168,6 @@ class MultipleInput extends InputWidget
         }
 
         if ($this->model instanceof Model) {
-            $this->model->refresh();
             $data = ($this->model->hasProperty($this->attribute) || isset($this->model->{$this->attribute}))
                 ? ArrayHelper::getValue($this->model, $this->attribute, [])
                 : [];

--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -198,7 +198,12 @@ abstract class BaseColumn extends BaseObject
         } else {
             $value = null;
             if ($data instanceof ActiveRecordInterface ) {
-                $value = $data->getAttribute($this->name);
+                if ($data->getRelation($this->name, false) && $data->canSetProperty($this->name)) {
+                    $value = $data->{$this->name};
+                } else {
+                    $value = $data->getAttribute($this->name);
+                }
+
             } elseif ($data instanceof Model) {
                 $value = $data->{$this->name};
             } elseif (is_array($data)) {

--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -198,12 +198,9 @@ abstract class BaseColumn extends BaseObject
         } else {
             $value = null;
             if ($data instanceof ActiveRecordInterface ) {
-                if ($data->getRelation($this->name, false) && $data->canSetProperty($this->name)) {
+                if ($data->canGetProperty($this->name)) {
                     $value = $data->{$this->name};
-                } else {
-                    $value = $data->getAttribute($this->name);
                 }
-
             } elseif ($data instanceof Model) {
                 $value = $data->{$this->name};
             } elseif (is_array($data)) {


### PR DESCRIPTION
Если использовать это расширение https://github.com/la-haute-societe/yii2-save-relations-behavior и задавать relation в качестве вложенного multiple input, то колонка обнуляет значение связанных моделей, поскольку у модели нет такого атрибута, а есть только релейшен. Хорошо-бы сменить способ получения атрибута на такой-же как и здесь:
https://github.com/unclead/yii2-multiple-input/blob/master/src/MultipleInput.php#L171
Тогда подобные расширения будут работать корректно.
Другие сценарии не тестировал. Но вроде работает. Раньше обходил это через задание виртуального атрибута, но это обрастает костылями.