### PR TITLE
Fix order of registered JS code block or files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii2 multiple input change log
 - #246 accept `\Traversable` in model attribute for `yield` compatibility (bscheshirwork) 
 - #250 accept `\Traversable` in TableRenderer and ListRenderer for `yield` compatibility (bscheshirwork)
 - #253 allow to omit a name for static column 
+- #257 added `jsPositions` property for the `BaseRenderer` to set right order js-code in `jsInit` and `jsTemplates` (Spell6inder)
 
 2.17.0
 ======

--- a/src/renderers/BaseRenderer.php
+++ b/src/renderers/BaseRenderer.php
@@ -184,6 +184,11 @@ abstract class BaseRenderer extends BaseObject implements RendererInterface
     public $jsExtraSettings = [];
 
     /**
+     * @var array List of the locations of registered JavaScript code block or files in right order.
+     */
+    public $jsPositions = [View::POS_HEAD, View::POS_BEGIN, View::POS_END, View::POS_READY, View::POS_LOAD];
+
+    /**
      * @inheritdoc
      */
     public function setContext($context)
@@ -370,8 +375,8 @@ abstract class BaseRenderer extends BaseObject implements RendererInterface
         // Collect all js scripts which has to be appended to page before initialization widget
         $jsInit = [];
         if (is_array($view->js)) {
-            foreach ($view->js as $position => $scripts) {
-                foreach ((array)$scripts as $key => $js) {
+            foreach ($this->jsPositions as $position) {
+                foreach (ArrayHelper::getValue($view->js, $position, []) as $key => $js) {
                     if (isset($jsBefore[$position][$key])) {
                         continue;
                     }
@@ -386,8 +391,8 @@ abstract class BaseRenderer extends BaseObject implements RendererInterface
 
         $jsTemplates = [];
         if (is_array($view->js)) {
-            foreach ($view->js as $position => $scripts) {
-                foreach ((array)$scripts as $key => $js) {
+            foreach ($this->jsPositions as $position) {
+                foreach (ArrayHelper::getValue($view->js, $position, []) as $key => $js) {
                     if (isset($jsBefore[$position][$key])) {
                         continue;
                     }


### PR DESCRIPTION
Some widgets declare their configuration in `View::POS_HEAD` and initialize in `View::POS_READY` and if earlier another widget is initialized only in `View::POS_READY` then the following situation arises `$view->js` contains such an array
```php
[
    4 => [// View::POS_READY
        // widget initialization
    ],
    1 => [// View::POS_HEAD
        // widget configuration
    ]
]
```
and then `$jsInit` fnd `$jsTemplates` contains such an array
```php
[
    // widget initialization
    // widget configuration
]
```
It means that widget initialization declare before his configuration.
Property `$jsPositions` added to the case if someone has his own implementation of `View`