### PR TITLE
Added support for ColumnOptions in BaseColumn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii2 multiple input change log
 - #250 accept `\Traversable` in TableRenderer and ListRenderer for `yield` compatibility (bscheshirwork)
 - #253 allow to omit a name for static column 
 - #257 added `jsPositions` property for the `BaseRenderer` to set right order js-code in `jsInit` and `jsTemplates` (Spell6inder)
+- #259 added `columnOptions` property in the `BaseColumn` for TableRenderer and ListRenderer to support HTML options of individual column (InsaneSkull)
 
 2.17.0
 ======

--- a/src/TabularColumn.php
+++ b/src/TabularColumn.php
@@ -18,23 +18,7 @@ use yii\base\Model;
  * @property TabularInput $context
  */
 class TabularColumn extends BaseColumn
-{
-    /**
-     * @var array|\Closure the HTML attributes for the indivdual table body column. This can be either an array
-     * specifying the common HTML attributes for indivdual body column, or an anonymous function that
-     * returns an array of the HTML attributes. It should have the following signature:
-     *
-     * ```php
-     * function ($model, $index, $context)
-     * ```
-     *
-     * - `$model`: the current data model being rendered
-     * - `$index`: the zero-based index of the data model in the model array
-     * - `$context`: the widget object
-     *
-     */
-    public $columnOptions = [];
-    
+{   
     /**
      * Returns element's name.
      *

--- a/src/TabularColumn.php
+++ b/src/TabularColumn.php
@@ -20,6 +20,11 @@ use yii\base\Model;
 class TabularColumn extends BaseColumn
 {
     /**
+     * @var array the HTML attributes for the body cell tag.
+     */
+    public $columnOptions = [];
+    
+    /**
      * Returns element's name.
      *
      * @param int|null|string $index current row index

--- a/src/TabularColumn.php
+++ b/src/TabularColumn.php
@@ -20,8 +20,8 @@ use yii\base\Model;
 class TabularColumn extends BaseColumn
 {
     /**
-     * @var array|\Closure the HTML attributes for the table body columns. This can be either an array
-     * specifying the common HTML attributes for all body column, or an anonymous function that
+     * @var array|\Closure the HTML attributes for the indivdual table body column. This can be either an array
+     * specifying the common HTML attributes for indivdual body column, or an anonymous function that
      * returns an array of the HTML attributes. It should have the following signature:
      *
      * ```php

--- a/src/TabularColumn.php
+++ b/src/TabularColumn.php
@@ -20,7 +20,18 @@ use yii\base\Model;
 class TabularColumn extends BaseColumn
 {
     /**
-     * @var array the HTML attributes for the body cell tag.
+     * @var array|\Closure the HTML attributes for the table body columns. This can be either an array
+     * specifying the common HTML attributes for all body column, or an anonymous function that
+     * returns an array of the HTML attributes. It should have the following signature:
+     *
+     * ```php
+     * function ($model, $index, $context)
+     * ```
+     *
+     * - `$model`: the current data model being rendered
+     * - `$index`: the zero-based index of the data model in the model array
+     * - `$context`: the widget object
+     *
      */
     public $columnOptions = [];
     

--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -144,7 +144,7 @@ abstract class BaseColumn extends BaseObject
      * - `$index`: the zero-based index of the data model in the model array
      * - `$context`: the widget object
      *
-     * @since 2.17.2
+     * @since 2.18.0
      */
     public $columnOptions = [];
     

--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -132,6 +132,23 @@ abstract class BaseColumn extends BaseObject
     public $nameSuffix;
 
     /**
+     * @var array|\Closure the HTML attributes for the indivdual table body column. This can be either an array
+     * specifying the common HTML attributes for indivdual body column, or an anonymous function that
+     * returns an array of the HTML attributes. It should have the following signature:
+     *
+     * ```php
+     * function ($model, $index, $context)
+     * ```
+     *
+     * - `$model`: the current data model being rendered
+     * - `$index`: the zero-based index of the data model in the model array
+     * - `$context`: the widget object
+     *
+     * @since 2.17.2
+     */
+    public $columnOptions = [];
+    
+    /**
      * @var Model|ActiveRecordInterface|array
      */
     private $_model;

--- a/src/renderers/ListRenderer.php
+++ b/src/renderers/ListRenderer.php
@@ -233,6 +233,14 @@ class ListRenderer extends BaseRenderer
             Html::addCssClass($options, 'form-group');
         }
 
+        if (is_callable($column->columnOptions)) {
+            $columnOptions = call_user_func($column->columnOptions, $column->getModel(), $index, $this->context);
+        } else {
+            $columnOptions = $column->columnOptions;
+        }
+
+        $options = array_merge_recursive($options, $columnOptions);
+        
         $content = Html::beginTag('div', $options);
 
         if (empty($column->title)) {

--- a/src/renderers/TableRenderer.php
+++ b/src/renderers/TableRenderer.php
@@ -308,9 +308,9 @@ class TableRenderer extends BaseRenderer
         
         $input = Html::tag('div', $input, $wrapperOptions);
 
-        return Html::tag('td', $input, [
-            'class' => 'list-cell__' . $column->name,
-        ]);
+        Html::addCssClass($column->columnOptions, 'list-cell__' . $column->name);
+
+        return Html::tag('td', $input, $column->columnOptions);
     }
 
 

--- a/src/renderers/TableRenderer.php
+++ b/src/renderers/TableRenderer.php
@@ -306,11 +306,17 @@ class TableRenderer extends BaseRenderer
             Html::addCssClass($wrapperOptions, 'has-error');
         }
         
+        if (is_callable($column->columnOptions)) {
+            $columnOptions = call_user_func($column->columnOptions, $column->getModel(), $index, $this->context);
+        } else {
+            $columnOptions = $column->columnOptions;
+        }
+
+        Html::addCssClass($columnOptions, 'list-cell__' . $column->name);
+        
         $input = Html::tag('div', $input, $wrapperOptions);
 
-        Html::addCssClass($column->columnOptions, 'list-cell__' . $column->name);
-
-        return Html::tag('td', $input, $column->columnOptions);
+        return Html::tag('td', $input, $columnOptions);
     }
 
 


### PR DESCRIPTION
I think, we can move `columnOptions` to BaseColumn by defining more generic name so it can be used for both ListRenderer and TableRenderer

#258 