### PR TITLE
Use .multiple-input-list instead global container for sorting

### DIFF
--- a/src/renderers/BaseRenderer.php
+++ b/src/renderers/BaseRenderer.php
@@ -431,7 +431,7 @@ abstract class BaseRenderer extends BaseObject implements RendererInterface
 
         // todo override when ListRenderer will use div markup
         $options = Json::encode($this->getJsSortableOptions());
-        $js = "$('#{$this->id}').sorting($options);";
+        $js = "$('#{$this->id} .multiple-input-list').sorting($options);";
         $view->registerJs($js);
     }
 


### PR DESCRIPTION
https://github.com/unclead/yii2-multiple-input/commit/4489740067a8ae76b9bb8c099e12731bd0b383ca#diff-1126b87be8aaf70abd5cbabc60164bf3R434

So... `containerSelector` from sortable config is not enough. 
#271
I try some wariants and select css clas as common case of first nested element.