### PR TITLE
Numeric option values disappeared

### DIFF
--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -359,7 +359,7 @@ abstract class BaseColumn extends BaseObject
         foreach ($options as $key => $value) {
             if (is_array($value)) {
                 $result[$key] = $this->replaceIndexPlaceholderInOptions($value, $indexPlaceholder, $index);
-            } elseif (is_string($value)) {
+            } else {
                 $result[$key] = str_replace('{' . $indexPlaceholder . '}', $index, $value);
             }
         }


### PR DESCRIPTION
Options that have a non-string value disappeared in the `replaceIndexPlaceholderInOptions `function.
Removed the `is_string() `check to allow to pass integer and float values.