### PR TITLE
FIX wrapper options for bootstrap theme

### DIFF
--- a/src/renderers/TableRenderer.php
+++ b/src/renderers/TableRenderer.php
@@ -309,7 +309,7 @@ class TableRenderer extends BaseRenderer
 
         $wrapperOptions = ['class' => 'field-' . $id];
         if ($this->isBootstrapTheme()) {
-            Html::addCssClass($options, 'form-group');
+            Html::addCssClass($wrapperOptions, 'form-group');
         }
 
         if ($hasError) {


### PR DESCRIPTION
I think this is just a typo.
Appropriate bootstrap classes for form field wrapper are missing.