### PR TITLE
Added ability for redefine assets js and css via config

### DIFF
--- a/src/assets/MultipleInputAsset.php
+++ b/src/assets/MultipleInputAsset.php
@@ -24,8 +24,12 @@ class MultipleInputAsset extends AssetBundle
     {
         $config = array_merge([
             'sourcePath' => __DIR__ . '/src/',
-            'js' => [YII_DEBUG ? 'js/jquery.multipleInput.js' : 'js/jquery.multipleInput.min.js'],
-            'css' => [YII_DEBUG ? 'css/multiple-input.css' : 'css/multiple-input.min.css'],
+            'js' => [
+                YII_DEBUG ? 'js/jquery.multipleInput.js' : 'js/jquery.multipleInput.min.js'
+            ],
+            'css' => [
+                YII_DEBUG ? 'css/multiple-input.css' : 'css/multiple-input.min.css'
+            ],
         ], $config);
 
         parent::__construct($config);

--- a/src/assets/MultipleInputAsset.php
+++ b/src/assets/MultipleInputAsset.php
@@ -20,19 +20,15 @@ class MultipleInputAsset extends AssetBundle
         'yii\web\JqueryAsset'
     ];
 
-    public function init()
+    public function __construct($config = [])
     {
-        $this->sourcePath = __DIR__ . '/src/';
+        $config = array_merge([
+            'sourcePath' => __DIR__ . '/src/',
+            'js' => [YII_DEBUG ? 'js/jquery.multipleInput.js' : 'js/jquery.multipleInput.min.js'],
+            'css' => [YII_DEBUG ? 'css/multiple-input.css' : 'css/multiple-input.min.css'],
+        ], $config);
 
-        $this->js = [
-            YII_DEBUG ? 'js/jquery.multipleInput.js' : 'js/jquery.multipleInput.min.js'
-        ];
-
-        $this->css = [
-            YII_DEBUG ? 'css/multiple-input.css' : 'css/multiple-input.min.css'
-        ];
-
-        parent::init();
+        parent::__construct($config);
     }
 
 

--- a/tests/unit/MultipleInputAssetTest.php
+++ b/tests/unit/MultipleInputAssetTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace unclead\multipleinput\tests\unit;
+use unclead\multipleinput\assets\MultipleInputAsset;
+
+/**
+ * Class MultipleInputAssetTest
+ * @package unclead\multipleinput\tests\unit
+ */
+class MultipleInputAssetTest extends TestCase
+{
+    public function testInit() {
+        $asset = new MultipleInputAsset();
+        $this->assertIsString($asset->sourcePath);
+        $this->assertCount(1, $asset->js);
+        $this->assertCount(1, $asset->css);
+    }
+
+    public function testSetEmptyJsViaConfig()
+    {
+        $asset = new MultipleInputAsset([
+            'js' => [],
+            'css' => [],
+            'sourcePath' => 'test',
+        ]);
+        $this->assertEquals('test', $asset->sourcePath);
+        $this->assertCount(0, $asset->js);
+        $this->assertCount(0, $asset->css);
+    }
+}

--- a/tests/unit/MultipleInputAssetTest.php
+++ b/tests/unit/MultipleInputAssetTest.php
@@ -9,7 +9,7 @@ use unclead\multipleinput\assets\MultipleInputAsset;
  */
 class MultipleInputAssetTest extends TestCase
 {
-    public function testInit() {
+    public function testConstuctor() {
         $asset = new MultipleInputAsset();
         $this->assertIsString($asset->sourcePath);
         $this->assertCount(1, $asset->js);


### PR DESCRIPTION
Это нужно для возможности обнуления файлов при объединении js и css через команду ./yii asset
Иначе их невозможно отключить и они всё-равно подцепляются в браузере, не смотря на то, что клиентский код уже есть в едином js-файле.