### PR TITLE
#347 separate input name generator method from error field name gener…

### DIFF
--- a/src/MultipleInputColumn.php
+++ b/src/MultipleInputColumn.php
@@ -49,7 +49,7 @@ class MultipleInputColumn extends BaseColumn
             $index = '{' . $this->renderer->getIndexPlaceholder() . '}';
         }
 
-        if ($this->isRendererHasOneColumn() && $this->hasModelAttribute($this->name)) {
+        if (empty($this->renderer->columns) || ($this->isRendererHasOneColumn() && $this->hasModelAttribute($this->name))) {
             $elementName = '[' . $index . ']';
         } else {
             $elementName = '[' . $index . '][' . $this->name . ']';
@@ -123,7 +123,7 @@ class MultipleInputColumn extends BaseColumn
             return null;
         }
 
-        if ($this->isRendererHasOneColumn() && $this->hasModelAttribute($this->name)) {
+        if (empty($this->renderer->columns) || ($this->isRendererHasOneColumn() && $this->hasModelAttribute($this->name))) {
             $attribute = $this->name . '[' . $index . ']';
         } else {
             $attribute = $this->context->attribute . '[' . $index . '][' . $this->name . ']';

--- a/src/MultipleInputColumn.php
+++ b/src/MultipleInputColumn.php
@@ -49,12 +49,10 @@ class MultipleInputColumn extends BaseColumn
             $index = '{' . $this->renderer->getIndexPlaceholder() . '}';
         }
 
-        $elementName = $this->isRendererHasOneColumn()
-            ? '[' . $this->name . '][' . $index . ']'
-            : '[' . $index . '][' . $this->name . ']';
-
-        if (!$withPrefix) {
-            return $elementName;
+        if ($this->isRendererHasOneColumn() && $this->hasModelAttribute($this->name)) {
+            $elementName = '[' . $index . ']';
+        } else {
+            $elementName = '[' . $index . '][' . $this->name . ']';
         }
 
         $prefix = $this->getInputNamePrefix();
@@ -87,7 +85,7 @@ class MultipleInputColumn extends BaseColumn
         $model = $this->context->model;
         if ($model instanceof Model) {
             if (empty($this->renderer->columns) || ($this->isRendererHasOneColumn() && $this->hasModelAttribute($this->name))) {
-                return $model->formName();
+                return Html::getInputName($this->context->model, $this->name);
             }
 
             return Html::getInputName($this->context->model, $this->context->attribute);
@@ -128,7 +126,7 @@ class MultipleInputColumn extends BaseColumn
         if ($this->isRendererHasOneColumn()) {
             $attribute = $this->name . '[' . $index . ']';
         } else {
-            $attribute = $this->context->attribute . $this->getElementName($index, false);
+            $attribute = $this->context->attribute . '[' . $index . '][' . $this->name . ']';
         }
 
         $model = $this->context->model;

--- a/src/MultipleInputColumn.php
+++ b/src/MultipleInputColumn.php
@@ -123,7 +123,7 @@ class MultipleInputColumn extends BaseColumn
             return null;
         }
 
-        if ($this->isRendererHasOneColumn()) {
+        if ($this->isRendererHasOneColumn() && $this->hasModelAttribute($this->name)) {
             $attribute = $this->name . '[' . $index . ']';
         } else {
             $attribute = $this->context->attribute . '[' . $index . '][' . $this->name . ']';


### PR DESCRIPTION
1. Возможные имена для input
ClassName[attr][index][field]
attr[index][field]

Если нет колонок или колонка одна и field есть в модели. Я бы добавил еще условие равенства имён attr=field.
ClassName[field][index]
field[index]
2. Метод для генерации input name используется и для генерации имени атрибута модели, на который будет присвоены ошибки. В этом изначальная причина бага. Имя атрибута для ошибок не обязательно привязывать к методу фреймворка для генерации input name. Заменять метод фреймворка для генерации input name не надо, чтобы не получать подобных багов.
3. Я бы добавил условие совпадения attr=name для генерации имени в виде ClassName[field][index] (field[index]).