### PR TITLE
Allow use inside Editable

### DIFF
--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -280,7 +280,7 @@ abstract class BaseColumn extends BaseObject
      * @return mixed
      */
     private function normalize($name) {
-        return str_replace(['[]', '][', '[', ']', ' ', '.'], ['', '-', '-', '', '-', '-'], strtolower($name));
+        return str_replace(['[]', '][', '[', ']', ' ', '.'], ['', '-', '-', '', '-', '-'], $name);
     }
 
     /**


### PR DESCRIPTION
IDs created by yii generateRandomString have capital and small letters, in the normalize function capital letters were removed only for indexPlaceholder and in id repained capital so it was not everywhere replaced in js Templates.